### PR TITLE
#126

### DIFF
--- a/amqtt/session.py
+++ b/amqtt/session.py
@@ -159,16 +159,15 @@ class Session:
 
     @property
     def next_packet_id(self):
-        self._packet_id += 1
-        if self._packet_id > 65535:
-            self._packet_id = 1
+        self._packet_id = (self._packet_id % 65535) + 1
+        limit = self._packet_id
         while (
             self._packet_id in self.inflight_in or self._packet_id in self.inflight_out
         ):
-            self._packet_id += 1
-            if self._packet_id > 65535:
+            self._packet_id = (self._packet_id % 65535) + 1
+            if self._packet_id == limit:
                 raise AMQTTException(
-                    "More than 65525 messages pending. No free packet ID"
+                    "More than 65535 messages pending. No free packet ID"
                 )
 
         return self._packet_id


### PR DESCRIPTION
- Updated protocol handlers to more reliably remove active waiters when task cancellation occurs
- Fixed checks where expecting a KeyError when it should be checking if not None
- Updated next_packet_id property to correctly check if there are any packet_ids available. Avoids infinite loop if all packet ids are used.